### PR TITLE
Update to debian trixie & update playit on run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-from debian:buster-slim
+FROM debian:trixie-slim
 
 RUN apt update && \
-    apt install -y curl gpg
+    apt install -y curl gnupg2
 
 RUN curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null && \
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.github.io/ppa/data ./" | tee /etc/apt/sources.list.d/playit-cloud.list
@@ -10,5 +10,6 @@ RUN apt update && \
     apt install -y playit
 
 RUN mkdir -p /secrets
+ADD run.sh /usr/local/bin/
 
-CMD ["playit", "--stdout", "--secret_path", "/secrets/playit.toml"]
+CMD ["bash", "/usr/local/bin/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+# make sure we're running latest version of the playit program
+apt update
+apt install -y playit
+
+playit --stdout --secret_path /secrets/playit.toml


### PR DESCRIPTION
This docker image is used by quite a few people on CasaOS. This update ensures users are on the latest version of playit by adding run.sh which will update apt and download the latest version on start.